### PR TITLE
Adding twitter link and fixing rss feed

### DIFF
--- a/_layouts/project.html.haml
+++ b/_layouts/project.html.haml
@@ -158,6 +158,8 @@
         - page.bottom_javascripts.each do |javascript|
           %script{:src=>javascript, :type=>'text/javascript'}
 
+      %script(src="https://cdnjs.cloudflare.com/ajax/libs/FeedEk/3.0.0/js/FeedEk.min.js")
+
       <!-- Google Analytics -->
       - if site.profile.eql?("staging") or site.profile.eql?("production")
         %script{:src => relative("/js/analytics.js"), :type=>"text/javascript"}

--- a/community/index.html.haml
+++ b/community/index.html.haml
@@ -31,8 +31,9 @@ title: Community
       All the latest Narayana project news and other interesting stuff is published in our blog.
     %a{:href => "http://jbossts.blogspot.co.uk", :class => "btn btn-primary"}
       Visit Narayana Blog
+
 .row
-  .col-md-12
+  .col-md-8
     %h1
       Mailing Lists
     %p
@@ -47,6 +48,14 @@ title: Community
             The archive is available at
             %a{:href => "http://lists.jboss.org/pipermail/jbossts-announce/"}
               http://lists.jboss.org/pipermail/jbossts-announce/
+  .col-md-4
+    %h1
+      Twitter
+    %p
+      We use hashtag #narayanaio
+    %a{:href => "https://twitter.com/hashtag/narayanaio", :class => "btn btn-primary"}
+      Twitter #narayanaio
+
 .row
   %h1 Our team
   .col-md-6
@@ -92,6 +101,8 @@ title: Community
       I joined the team with 5 years experience of QE engineer for JBoss EAP.
     %p
       Prior to work at Red Hat I gained experience in PHP web and Java EE logistic system development.
+    .div{:style => "height: 250px"}
+      %a{:class => "twitter-timeline", :href => "https://twitter.com/_chalda", :height => "250"}
 
 .row
   .col-md-6


### PR DESCRIPTION
This was not an easy task at the end.

I was trying to find out if there is possible to embed the twitter feed from hash tag. It seems it was functionality that worked but in these days it's not possible. See https://twittercommunity.com/t/deprecating-widget-settings/102295 . I was checking the recommended TweetDeck and publish.twitter.com but that was not what we needed.
That way I added only "a button" to the community page.

The next part was fixing rss feed to work. After investigation I found there is used old FeedEk jquery plugin at boostrap community library (http://static.jboss.org/theme/js/libs/bootstrap-community/3.2.0.0/). Thus I replaced the usage with newer FeedEk which uses yahoo api instead of google.