### PR TITLE
Put the twitter information on the same line

### DIFF
--- a/community/index.html.haml
+++ b/community/index.html.haml
@@ -57,7 +57,7 @@ title: Community
       We use hashtag #narayanaio
     %a{:href => "https://twitter.com/hashtag/narayanaio", :class => "btn btn-primary"}
       Twitter #narayanaio
-    .col-md-6
+  .col-md-6
     %h2
       Narayana_IO
     %h3


### PR DESCRIPTION
I expected the two twitter items to be on the same row but they were not:
http://narayanaci1.eng.hst.ams2.redhat.com/view/Narayana/job/narayana-io/412/artifact/_site/community/index.html

Hopefully with this PR they are on the same row now