### PR TITLE
[JBTM-3857] Do use relativeURLs in serverless mode only

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ Clone this repository (or your fork).
 To build the website:
 ```
 npm install
-npm run build
+npm run build -- -b https://www.narayana.io/
 ```
+To build the website the a specific configuration:
 
+```
+npm install
+HUGO_ENV=serverless npm run build
+```
 
 To run a preview of the website on a local server:
 ```

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,4 +1,3 @@
-relativeURLs = true
 disableAliases = true
 disableHugoGeneratorInject = true
 enableEmoji = true

--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -2,46 +2,46 @@
   name = "Prologue"
   weight = 10
   identifier = "prologue"
-  url = "/docs/prologue/"
+  pageRef = "/docs/prologue/"
 
 [[docs]]
   name = "Help"
   weight = 60
   identifier = "help"
-  url = "/docs/help/"
+  pageRef = "/docs/help/"
 
 # [[docs]]
 #   name = "Lorem"
 #   weight = 70
 #   identifier = "lorem"
-#   url = "/docs/lorem/"
+#   pageRef = "/docs/lorem/"
 
 [[guide]]
   name = "Lorem"
   weight = 10
   identifier = "lorem"
-  url = "/guide/lorem/"
+  pageRef = "/guide/lorem/"
 
 [[tutorial]]
   name = "Lorem"
   weight = 10
   identifier = "lorem"
-  url = "/tutorial/lorem/"
+  pageRef = "/tutorial/lorem/"
 
 [[main]]
   name = "Documentation"
-  url = "/documentation/"
-# url = "/docs/1.0/prologue/introduction/"
+  pageRef = "/documentation/"
+# pageRef = "/docs/1.0/prologue/introduction/"
   weight = 20
 
 # [[main]]
 #   name = "Tutorial"
-#   url = "/tutorial/lorem/ipsum/"
+#   pageRef = "/tutorial/lorem/ipsum/"
 #   weight = 15
 
 [[main]]
   name = "Downloads"
-  url = "/downloads/"
+  pageRef = "/downloads/"
   weight = 10
 
 
@@ -49,13 +49,13 @@
   name = "Community"
   weight = 40
   identifier = "community"
-  url = "/community/"
+  pageRef = "/community/"
 
 [[main]]
   name = "Source Code"
   weight = 50
   identifier = "github"
-  url= "https://github.com/jbosstm"
+  url = "https://github.com/jbosstm"
 
 [[main]]
   name = "Issue Tracker"
@@ -67,7 +67,7 @@
   name = "Certifications"
   weight = 70
   identifier = "certifications"
-  url = "/certifications/"
+  pageRef = "/certifications/"
 
 [[social]]
   name = "GitHub"
@@ -85,5 +85,5 @@
 
 # [[footer]]
 #   name = "Privacy"
-#   url = "/privacy-policy/"
+#   pageRef = "/privacy-policy/"
 #   weight = 10

--- a/config/next/config.toml
+++ b/config/next/config.toml
@@ -1,1 +1,0 @@
-relativeURLs = true

--- a/config/production/hugo.toml
+++ b/config/production/hugo.toml
@@ -1,1 +1,0 @@
-relativeURLs = true

--- a/config/serverless/config.toml
+++ b/config/serverless/config.toml
@@ -1,0 +1,1 @@
+relativeURLs = true


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3857

relativeURLs is only meant for serverless mode, so removing it by default.
(Sintax) Update also local 'url' to  'pageRef'