### PR TITLE
Update bug submission link in custom footer

### DIFF
--- a/layouts/_partials/footer/custom-footer.html
+++ b/layouts/_partials/footer/custom-footer.html
@@ -33,7 +33,7 @@
     <div class="col-md-4">
         <h4>Contribute</h4>
         <ul class="list-unstyled">
-            <li> <a href="https://issues.jboss.org/browse/JBTM/" title="Submit a bug">Submit a bug</a> </li>
+            <li> <a href="https://github.com/jbosstm/narayana/issues" title="Submit a bug">Submit a bug</a> </li>
             <li> <a href="https://github.com/jbosstm" title="Write code">Write Code</a> </li>
             <li> <a href="/governance/" title="Governance">Governance</a> </li>
         </ul>


### PR DESCRIPTION
Update bug submission link in custom footer to align to the new GitHub issue tracker

<img width="1697" height="757" alt="Screenshot From 2026-07-27 12-34-34" src="https://github.com/user-attachments/assets/3e4861c1-bc1e-429b-86fc-444e575db910" />
